### PR TITLE
Fix connectivity issues, switch from http-bind to websocket

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,4 +61,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./frontend/dist
           destination_dir: ${{ steps.determine_sublocation.outputs.sublocation }}
-          cname: jimmi.xyz
+          cname: app.jimmi.party

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
   <a href="https://meet.jit.si/">
     <img src="https://img.shields.io/badge/Built%20for-Jitsi%20Meet-5e87d4" />
   </a>
-  <a href="https://jimmi.xyz/">
-    <img src="https://img.shields.io/badge/https://-jimmi.xyz-6366f1" />
+  <a href="https://app.jimmi.party/">
+    <img src="https://img.shields.io/badge/https://-app.jimmi.party-6366f1" />
   </a>
 </p>
 
@@ -47,7 +47,7 @@ I am Jimmi! Your Jitsi Integrated Musicbot Management Interface.
 
 # :tada: How does Jimmi help me?
 
-An awesome Jitsi Meet Party has never been so easy! - Go to [jimmi.xyz](https://jimmi.xyz/) fill in the party location and start listening to your music with your friends!
+An awesome Jitsi Meet Party has never been so easy! - Go to [app.jimmi.party](https://app.jimmi.party/) fill in the party location and start listening to your music with your friends!
 
 :warning: Remember that you have to install the browser extension before. See below for how to install.
 
@@ -75,7 +75,7 @@ Installation of the extension depends on your browser and is easiest in Chromium
 2. On the right hand side of the navigation bar activate the *Developer mode*
 3. Then press *Load unpacked*
 4. Select the `browser` folder
-5. Navigate to [jimmi.xyz](https://jimmi.xyz/) and let the party begin!
+5. Navigate to [app.jimmi.party](https://app.jimmi.party/) and let the party begin!
 
 # :blue_book: License
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ At the moment Jimmi only supports simple music playback but he already has an ex
 
 # :rocket: Get started!
 
-Caused by the [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/de/docs/Web/HTTP/CORS) restrictions you need a browser extension to load external YouTube videos into your session and, depending on their configuration, connect to a foreign Jitsi instance.
+Caused by the [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/de/docs/Web/HTTP/CORS) restrictions you need a browser extension to load external YouTube videos into your session.
 
 There have been approaches to circumvent this CORS issues, e.g. the [v2 release of Jimmi](https://github.com/Music-Bot-for-Jitsi/Jimmi/releases/tag/v2.0.0) that you can treet like an April Fool because it was unmaintainable and very resource intensive. For the sake of simplicity and security, it has been decided to deal with the CORS restrictions using the declarativeNetRequest feature of Manifest V3.
 

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -14,7 +14,7 @@
         "declarativeNetRequest"
     ],
     "host_permissions": [
-        "https://jimmi.xyz/*",
+        "https://app.jimmi.party/*",
         "https://*.googlevideo.com/*",
         "https://*/http-bind*"
     ],

--- a/browser/manifest.json
+++ b/browser/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "JIMMI Media",
-    "version": "1.0",
+    "version": "1.1",
     "declarative_net_request": {
         "rule_resources": [
             {
@@ -15,8 +15,7 @@
     ],
     "host_permissions": [
         "https://app.jimmi.party/*",
-        "https://*.googlevideo.com/*",
-        "https://*/http-bind*"
+        "https://*.googlevideo.com/*"
     ],
     "manifest_version": 3
 }

--- a/browser/rules.json
+++ b/browser/rules.json
@@ -33,7 +33,7 @@
                 {
                     "header": "access-control-allow-origin",
                     "operation": "set",
-                    "value": "https://jimmi.xyz"
+                    "value": "https://app.jimmi.party"
                 },
                 {
                     "header": "access-control-allow-headers",

--- a/browser/rules.json
+++ b/browser/rules.json
@@ -23,32 +23,5 @@
                 "media"
             ]
         }
-    },
-    {
-        "id": 2,
-        "priority": 1,
-        "action": {
-            "type": "modifyHeaders",
-            "responseHeaders": [
-                {
-                    "header": "access-control-allow-origin",
-                    "operation": "set",
-                    "value": "https://app.jimmi.party"
-                },
-                {
-                    "header": "access-control-allow-headers",
-                    "operation": "set",
-                    "value": "*"
-                },
-                {
-                    "header": "access-control-allow-methods",
-                    "operation": "set",
-                    "value": "GET, POST, OPTIONS"
-                }
-            ]
-        },
-        "condition": {
-            "urlFilter": "*http-bind"
-        }
     }
 ]

--- a/frontend/src/components/Jitsi.svelte
+++ b/frontend/src/components/Jitsi.svelte
@@ -156,9 +156,9 @@
   /**
    * Called when connection fails
    */
-  function onConnectionFailed() {
-    alert("Connection failed! Please report this issue");
-    console.error("Connection Failed!");
+  function onConnectionFailed(err) {
+    alert(`Connection failed (${err})! Please report this issue`);
+    console.error("Connection failed!", err);
   }
 
   /**

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -10,7 +10,7 @@ export const config = {
     initialVolume: 20, // default initial audio volume
   },
   repoUrl: "https://github.com/p-fruck/Jimmi",
-  url: "https://jimmi.xyz", // the redirect url when clicking on the navbar logo
+  url: "https://app.jimmi.party", // the redirect url when clicking on the navbar logo
   logo: "/jimmi.svg", // location of the logo displayed in navbar
   plugins: [MusicPlugin, ModeratorPlugin], // list of all plugins
 }

--- a/frontend/src/routes/Bot.svelte
+++ b/frontend/src/routes/Bot.svelte
@@ -53,7 +53,7 @@
         domain: params.instance,
         muc: `conference.${params.instance}`, // FIXME: use XEP-0030
       },
-      bosh: `https://${params.instance}/http-bind?room=${params.room}`,
+      serviceUrl: `https://${params.instance}/http-bind?room=${params.room}`,
     };
     await jitsi.joinConference(options); // jimmiApi is initialized during function call
 

--- a/frontend/src/routes/Bot.svelte
+++ b/frontend/src/routes/Bot.svelte
@@ -50,10 +50,11 @@
   onMount(async () => {
     const options = {
       hosts: {
+        anonymousdomain: `guest.${params.instance}`,
         domain: params.instance,
         muc: `conference.${params.instance}`, // FIXME: use XEP-0030
       },
-      serviceUrl: `https://${params.instance}/http-bind?room=${params.room}`,
+      serviceUrl: `wss://${params.instance}/xmpp-websocket?room=${params.room}`,
     };
     await jitsi.joinConference(options); // jimmiApi is initialized during function call
 


### PR DESCRIPTION
## Description

Fixes the connectivity issues reported in #154. The `bosh` parameter has been changed to `serviceUrl` in `lib-jitsi-meet` which supports websockets instead of `http-bind`. Websocket are apparently not subject to CORS so the http-bind related stuff has been removed from the browser extension. The extension is now solely required for streaming from google video, meaning that Jimmi could be used as a Chatbot without the plugin.

## Checklist
<!--
  Go over all the following points, and put an `x` in all boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] Make sure you are requesting to `dev`. Don't request to `main` branch!
- [x] I have linked related issue.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
